### PR TITLE
Show Share button on desktop version

### DIFF
--- a/packages/telescope-theme-hubble/lib/client/scss/modules/_posts.scss
+++ b/packages/telescope-theme-hubble/lib/client/scss/modules/_posts.scss
@@ -41,6 +41,17 @@
 	font-size: 22px;
 }
 
+.single-post {
+	@include medium-large {
+		.post-discuss {
+  			display: none;
+		}
+		.post-share {
+  			display: block;
+		}
+	}
+}
+
 // ------------------------------------ posts views nav ------------------------------------ //
 .posts-views-nav{
 	background: white(0.6);


### PR DESCRIPTION
Via CSS, I've showed the share button and hide the discuss icon on the post's page. Basically, the share button replaces the real estate of the discuss icon because we are already on the post's page, and we still have the comment link/count in the post's meta.

For those looking for the share button on the posts list (homepage), don't worry because Sacha is going to make the post title redirect to the page of the post. You can see it here: https://github.com/TelescopeJS/Telescope/commit/285aa810d110320493a1e8498067bddf197fba6c . So your users are still going to see the share button. :)